### PR TITLE
Fix the version in package.json file while GHA call image build

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -10,6 +10,9 @@ on:
       environment:
         required: true
         type: string
+      commit_sha:
+        required: false
+        type: string
 
 env:
   ECR_REPOSITORY: "metaallocator-dapp"
@@ -26,6 +29,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/publish-new-build.yml
+++ b/.github/workflows/publish-new-build.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: code-check
     if: ${{ github.ref_name == 'main' && inputs.version != '' }}
+    outputs:
+      commit_sha: ${{ steps.commit-version.outputs.commit_sha }}
 
     steps:
       - name: Checkout code
@@ -56,9 +58,11 @@ jobs:
           git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
       - name: Commit version change
+        id: commit-version
         run: |
           git commit -am "Update version to ${{ inputs.version }}"
           git push origin main
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
   staging-publish:
     uses: ./.github/workflows/build-docker-image.yml
@@ -72,6 +76,7 @@ jobs:
     with:
       environment: production-fidl # staging the same as production
       version: ${{ inputs.version }}
+      commit_sha: ${{ github.ref_name == 'main' && inputs.version != '' && needs.bump-version.outputs.commit_sha || '' }}
     secrets: inherit
 
   production-publish:
@@ -87,11 +92,14 @@ jobs:
     with:
       environment: production-fidl
       version: ${{ inputs.version }}
+      commit_sha: ${{ needs.bump-version.outputs.commit_sha }}
     secrets: inherit
 
   git-tag:
     runs-on: ubuntu-latest
-    needs: production-publish
+    needs:
+      - bump-version
+      - production-publish
     if: |
       ${{ github.ref_name == 'main' && inputs.version != '' }} &&
       always() &&
@@ -100,6 +108,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump-version.outputs.commit_sha }}
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
Issue: 
The docker image doesn't contain the updated version in `package.json` while the image build was called by GHA.

Solution:
Pass the sha commit after the update version into staging/production jobs to pull on the right one 